### PR TITLE
Use local default font path

### DIFF
--- a/src/terminal/terminal.gd
+++ b/src/terminal/terminal.gd
@@ -8,7 +8,7 @@ enum RIGHTCLICK_MENU_ITEMS {
 
 const GODOT_DEFAULT_FONT_SIZE: int = 16
 
-@export var font_file: FontFile = preload("res://fonts/monospaced/DejaVu_Sans/DejaVuSansMono.ttf")
+@export var font_file: FontFile = preload("../fonts/monospaced/DejaVu_Sans/DejaVuSansMono.ttf")
 @export var font_size: int = 22
 @export var default_text_color: Color = Color.WHITE
 @export var prompt_color: Color = Color.GREEN


### PR DESCRIPTION
Preloading the default font using an absolute path causes a parse error if the `fonts` directory isn't at the project root. Using a local path instead allows the `fonts` and `terminal` directories to be copied into a subfolder of a new project and used as an addon